### PR TITLE
Improve energy efficiency by applying Cache Energy Pattern

### DIFF
--- a/TinyTinyFeed/src/main/java/org/poopeeland/tinytinyfeed/network/Fetcher.java
+++ b/TinyTinyFeed/src/main/java/org/poopeeland/tinytinyfeed/network/Fetcher.java
@@ -29,9 +29,7 @@ import java.io.ObjectOutputStream;
 import java.net.UnknownHostException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -71,19 +69,19 @@ public class Fetcher {
             new X509TrustManager() {
                 @Override
                 @SuppressLint("TrustAllX509TrustManager")
-                public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
                     // Do nothing because everybody is beautiful
                 }
 
                 @Override
                 @SuppressLint("TrustAllX509TrustManager")
-                public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
                     // Do nothing because everything is awesome
                 }
 
                 @Override
-                public X509Certificate[] getAcceptedIssuers() {
-                    return new X509Certificate[]{};
+                public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                    return new java.security.cert.X509Certificate[]{};
                 }
             }
     };

--- a/TinyTinyFeed/src/main/java/org/poopeeland/tinytinyfeed/network/Fetcher.java
+++ b/TinyTinyFeed/src/main/java/org/poopeeland/tinytinyfeed/network/Fetcher.java
@@ -40,7 +40,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import javax.net.ssl.*;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.SSLSessionContext;
 
 import okhttp3.Call;
 import okhttp3.Credentials;


### PR DESCRIPTION
This improves the energy efficiency of fistons by applying the Cache Energy Pattern for mobile applications.

The energy pattern was applied in Fletcher.java. The general idea is to avoid performing unnecessary operations by increasing the size of the cache used. In particular, when a SSLContext is created, if the size of the cache has a limit, it's set to have no limit.